### PR TITLE
Make the plugin ready for QGIS publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - run: python -m compileall -q src plugin scripts tests benchmarks
       - run: pytest
       - run: python scripts/build_plugin.py
+      - name: Run QGIS publication security gate
+        if: matrix.python-version == '3.13'
+        run: python scripts/check_qgis_plugin_security.py
 
   qgis-ltr:
     name: Boot plugin and MCP smoke test on QGIS LTR 3.44.12

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The bridge accepts only authenticated local connections and does not expose arbi
 
 ## Compatibility
 
-- QGIS 3.28 or newer
+- QGIS 3.44 LTR or newer in the 3.x series
 - Codex, Claude Code and standard stdio MCP clients
 - No external Python runtime dependency in the packaged plugin
 - Validated on QGIS LTR 3.44.12 with 19 live integration scenarios
 
-Experimental release. Licensed under the [MIT License](LICENSE).
+Licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The agent can also search the complete specialist catalog without loading every 
 
 ## Safety
 
-The bridge accepts only authenticated local connections. Arbitrary Python execution is disabled by default and must be enabled explicitly with `QGIS_MCP_ENABLE_PYTHON=1`.
+The bridge accepts only authenticated local connections and does not expose arbitrary Python execution. Agents use typed tools, QGIS Processing algorithms and guarded workflows instead.
 
 ## Compatibility
 

--- a/plugin/qgis_agent_mcp/.flake8
+++ b/plugin/qgis_agent_mcp/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203,E501,W391,W503

--- a/plugin/qgis_agent_mcp/bridge.py
+++ b/plugin/qgis_agent_mcp/bridge.py
@@ -125,7 +125,7 @@ class LocalBridge(QObject):
                     "authenticated": True,
                     "protocol": PROTOCOL_VERSION,
                     "qgis_version": Qgis.QGIS_VERSION,
-                    "python_execution_enabled": self.dispatcher.python_enabled,
+                    "python_execution_enabled": False,
                 },
             )
             return

--- a/plugin/qgis_agent_mcp/dispatcher.py
+++ b/plugin/qgis_agent_mcp/dispatcher.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import contextlib
-import io
 import json
 import os
-import sys
 import time
 import traceback
 from urllib.parse import unquote, urlparse
@@ -76,7 +73,6 @@ MUTATION_METHODS = {
     "capabilities.invoke",
     "processing.start",
     "operation.control",
-    "python.exec",
     "ui.invoke",
     "batch.execute",
     "artifact.release",
@@ -185,12 +181,6 @@ class Dispatcher:
         self.objects = ObjectRegistry(iface)
         self.capabilities = CapabilityIndex(iface, self.objects)
         self.operations = OperationManager(self.log, self.state, self.artifacts)
-        self.python_enabled = _truthy(os.environ.get("QGIS_MCP_ENABLE_PYTHON"))
-        self._python_globals = {
-            "__builtins__": __builtins__,
-            "iface": iface,
-            "project": QgsProject.instance(),
-        }
         self._methods = {
             "session.snapshot": self.session_snapshot,
             "project.inspect": self.project_inspect,
@@ -204,7 +194,6 @@ class Dispatcher:
             "capabilities.invoke": self.capabilities_invoke,
             "processing.start": self.processing_start,
             "operation.control": self.operation_control,
-            "python.exec": self.python_exec,
             "ui.search": self.ui_search,
             "ui.invoke": self.ui_invoke,
             "ui.screenshot": self.ui_screenshot,
@@ -440,7 +429,7 @@ class Dispatcher:
         if detail != "summary":
             result["capabilities"] = self.capabilities.summary()
             result["operations"] = self.operations.list_public()
-            result["python_execution_enabled"] = self.python_enabled
+            result["python_execution_enabled"] = False
             result["open_windows"] = [
                 self.objects.summarize(runtime_id, obj)
                 for runtime_id, obj in self.objects.refresh().items()
@@ -791,55 +780,6 @@ class Dispatcher:
     def operation_control(self, operation_id, action="status"):
         return self.operations.control(operation_id, action)
 
-    def python_exec(
-        self, code, mode="exec", result_expression=None, timeout_ms=30000
-    ):
-        if not self.python_enabled:
-            raise DispatchError(
-                -32020,
-                "Python execution is disabled",
-                {
-                    "enable": (
-                        "Set QGIS_MCP_ENABLE_PYTHON=1 before starting QGIS. "
-                        "This grants arbitrary code execution in the QGIS process."
-                    )
-                },
-            )
-        if mode not in {"eval", "exec"}:
-            raise ValueError("mode must be eval or exec")
-        started = time.monotonic()
-        deadline = started + int(timeout_ms) / 1000.0
-        stdout, stderr = io.StringIO(), io.StringIO()
-        previous_trace = sys.gettrace()
-
-        def deadline_trace(frame, event, arg):
-            if time.monotonic() > deadline:
-                raise TimeoutError("Python execution exceeded timeout_ms")
-            return deadline_trace
-
-        result = None
-        try:
-            sys.settrace(deadline_trace)
-            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
-                if mode == "eval":
-                    result = eval(code, self._python_globals, self._python_globals)
-                else:
-                    exec(code, self._python_globals, self._python_globals)
-                    if result_expression:
-                        result = eval(
-                            result_expression, self._python_globals, self._python_globals
-                        )
-        finally:
-            sys.settrace(previous_trace)
-        self.state.touch("python.executed", {"mode": mode})
-        return {
-            "result": json_safe(result),
-            "stdout": stdout.getvalue(),
-            "stderr": stderr.getvalue(),
-            "elapsed_ms": round((time.monotonic() - started) * 1000, 3),
-            "note": "The timeout can interrupt Python bytecode, not blocking C++/provider calls.",
-        }
-
     def ui_search(self, query="", types=None, visible_only=True, limit=50):
         needle = query.casefold().strip()
         wanted = {item.casefold() for item in types} if types else None
@@ -1054,10 +994,10 @@ class Dispatcher:
                 raise ValueError("correction_calls are required for action=apply")
             if len(correction_calls) > 25:
                 raise ValueError("At most 25 correction calls are allowed")
-            forbidden = {"batch.execute", "visual.review", "workflow.execute", "python.exec"}
+            forbidden = {"batch.execute", "visual.review", "workflow.execute"}
             requested_methods = {str(call.get("method")) for call in correction_calls}
             if requested_methods & forbidden:
-                raise ValueError("Nested orchestration and Python corrections are not allowed")
+                raise ValueError("Nested orchestration corrections are not allowed")
             preflight = self.runtime_tools.preflight(correction_calls)
             if not preflight["valid"]:
                 raise ValueError("Visual correction preflight failed: {}".format(preflight["errors"]))
@@ -1600,10 +1540,6 @@ def _resource(uri, name, state):
         "mimeType": "application/json",
         "revision": state.resource_revision(uri),
     }
-
-
-def _truthy(value):
-    return str(value or "").strip().casefold() in {"1", "true", "yes", "on"}
 
 
 class QgsApplicationMessageLog:

--- a/plugin/qgis_agent_mcp/metadata.txt
+++ b/plugin/qgis_agent_mcp/metadata.txt
@@ -2,19 +2,22 @@
 name=QGIS Agent MCP
 description=Connect AI agents to QGIS through a secure, one-click local MCP bridge
 version=0.4.2
-qgisMinimumVersion=3.28
+qgisMinimumVersion=3.44
+qgisMaximumVersion=3.99
 author=Auguste Sagaert
 email=auguste.sagaert@gmail.com
 about=Connect Codex, Claude Code and other MCP clients to a live QGIS Desktop session.
-    Access 100+ specialist tools while an adaptive catalog keeps the default context small.
-    Run safe, resumable workflows with visual map review through an authenticated local bridge.
-experimental=True
+    Requires a local MCP-compatible AI client; no additional Python package or cloud account is needed.
+    Access 100+ typed specialist tools while an adaptive catalog keeps the default context small.
+    Run guarded, resumable workflows with restart recovery and visual map review.
+    Arbitrary Python execution is not exposed, and project data stays inside QGIS.
+experimental=False
 deprecated=False
 hasProcessingProvider=False
 server=False
-tags=MCP,AI agents,automation,PyQGIS,Processing,cartography
+tags=mcp,ai,agent,automation,cartography,workflow
 homepage=https://github.com/Aaa2122/QGIS-MCP
 repository=https://github.com/Aaa2122/QGIS-MCP
 tracker=https://github.com/Aaa2122/QGIS-MCP/issues
 icon=icon.png
-changelog=0.4.2 - Adaptive specialist tool catalog, restart recovery and visual review.
+changelog=0.4.2 - Secure adaptive tool catalog, restart recovery, visual review and one-click client setup.

--- a/plugin/qgis_agent_mcp/plugin.py
+++ b/plugin/qgis_agent_mcp/plugin.py
@@ -92,7 +92,7 @@ class QgisAgentMcpPlugin:
         else:
             message = (
                 "Listening on 127.0.0.1:{}; {} authenticated client(s); "
-                "Python execution {}"
+                "arbitrary Python execution unavailable"
             ).format(
                 self.bridge.port,
                 sum(
@@ -100,7 +100,6 @@ class QgisAgentMcpPlugin:
                     for state in self.bridge.clients.values()
                     if state["authenticated"]
                 ),
-                "enabled" if self.dispatcher.python_enabled else "disabled",
             )
             level = Qgis.Info
         self.iface.messageBar().pushMessage(

--- a/plugin/qgis_agent_mcp/runtime_tools.py
+++ b/plugin/qgis_agent_mcp/runtime_tools.py
@@ -253,7 +253,7 @@ class RuntimeTools:
             if not isinstance(params, dict):
                 errors.append({"index": index, "method": method, "message": "params must be an object"})
                 params = {}
-            if method in {"python.exec", "ui.invoke", "capabilities.invoke"}:
+            if method in {"ui.invoke", "capabilities.invoke"}:
                 warnings.append({"index": index, "method": method, "message": "escape hatch requires elevated trust"})
             normalized.append(
                 {
@@ -337,7 +337,7 @@ class RuntimeTools:
         policy = getattr(self.data_manager, "policy", None)
         output_policy = getattr(self.layout_manager, "output_policy", None)
         return {
-            "python_execution": bool(os.environ.get("QGIS_MCP_ENABLE_PYTHON")),
+            "python_execution": False,
             "network": {
                 "private_hosts_allowed": bool(getattr(policy, "allow_private", False)),
                 "allowed_hosts": sorted(getattr(policy, "allowed_hosts", set())),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,15 @@ authors = [{name = "QGIS MCP contributors"}]
 dependencies = []
 
 [project.optional-dependencies]
-dev = ["pytest>=8", "pytest-asyncio>=0.23", "pytest-timeout>=2.3", "ruff>=0.12"]
+dev = [
+    "bandit>=1.9",
+    "detect-secrets>=1.5",
+    "flake8>=7.3",
+    "pytest>=8",
+    "pytest-asyncio>=0.23",
+    "pytest-timeout>=2.3",
+    "ruff>=0.12",
+]
 
 [project.scripts]
 qgis-mcp = "qgis_mcp.__main__:main"

--- a/scripts/check_qgis_plugin_security.py
+++ b/scripts/check_qgis_plugin_security.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path, PurePosixPath
+
+MAX_PACKAGE_BYTES = 25 * 1024 * 1024
+REQUIRED_FILES = {"metadata.txt", "__init__.py", "LICENSE"}
+ALLOWED_HIDDEN_FILES = {".bandit", ".flake8", ".secrets.baseline"}
+BINARY_SUFFIXES = {".bin", ".class", ".dll", ".dylib", ".exe", ".jar", ".pyd", ".so"}
+
+# Active CRITICAL Bandit rules from the QGIS Plugins security rules reference.
+QGIS_BLOCKING_BANDIT_RULES = {
+    "B102",
+    "B103",
+    "B105",
+    "B106",
+    "B107",
+    "B111",
+    "B201",
+    "B202",
+    "B301",
+    "B302",
+    "B304",
+    "B305",
+    "B306",
+    "B307",
+    "B312",
+    "B321",
+    "B323",
+    "B401",
+    "B402",
+    "B412",
+    "B413",
+    "B501",
+    "B502",
+    "B503",
+    "B505",
+    "B506",
+    "B507",
+    "B601",
+    "B602",
+    "B604",
+    "B605",
+    "B609",
+    "B610",
+    "B611",
+    "B612",
+    "B613",
+    "B615",
+    "B701",
+}
+
+
+def validate_package_structure(package: Path) -> tuple[str, list[str]]:
+    issues: list[str] = []
+    if package.stat().st_size > MAX_PACKAGE_BYTES:
+        issues.append("package exceeds the QGIS 25 MB limit")
+    with zipfile.ZipFile(package) as archive:
+        names = [name for name in archive.namelist() if name and not name.endswith("/")]
+    roots = {PurePosixPath(name).parts[0] for name in names}
+    if len(roots) != 1:
+        return "", ["package must contain exactly one root directory"]
+    root = roots.pop()
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_-]*", root):
+        issues.append("plugin root name contains unsupported characters")
+    relative_names = {
+        str(PurePosixPath(*PurePosixPath(name).parts[1:])) for name in names
+    }
+    missing = sorted(REQUIRED_FILES - relative_names)
+    if missing:
+        issues.append("missing required files: {}".format(", ".join(missing)))
+    for name in names:
+        path = PurePosixPath(name)
+        if path.is_absolute() or ".." in path.parts:
+            issues.append("unsafe archive path: {}".format(name))
+        if Path(path.name).suffix.casefold() in BINARY_SUFFIXES:
+            issues.append("binary file is not allowed: {}".format(name))
+        for part in path.parts[1:]:
+            if part.startswith(".") and part not in ALLOWED_HIDDEN_FILES:
+                issues.append("unexpected hidden path: {}".format(name))
+                break
+        if "__pycache__" in path.parts or path.suffix.casefold() in {".pyc", ".pyo"}:
+            issues.append("generated Python cache is not allowed: {}".format(name))
+    return root, sorted(set(issues))
+
+
+def _run(command: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def scan_package(package: Path) -> list[str]:
+    root_name, issues = validate_package_structure(package)
+    if issues:
+        return issues
+    with tempfile.TemporaryDirectory(prefix="qgis-plugin-security-") as temporary:
+        temporary_path = Path(temporary).resolve()
+        with zipfile.ZipFile(package) as archive:
+            for member in archive.infolist():
+                destination = (temporary_path / member.filename).resolve()
+                if temporary_path not in destination.parents and destination != temporary_path:
+                    return ["unsafe archive path: {}".format(member.filename)]
+                archive.extract(member, temporary_path)
+        plugin_root = temporary_path / root_name
+
+        bandit = _run(
+            [sys.executable, "-m", "bandit", "-r", str(plugin_root), "-f", "json"]
+        )
+        try:
+            bandit_data = json.loads(bandit.stdout)
+        except json.JSONDecodeError:
+            issues.append("Bandit did not return valid JSON: {}".format(bandit.stderr.strip()))
+        else:
+            for finding in bandit_data.get("results", []):
+                if finding.get("test_id") in QGIS_BLOCKING_BANDIT_RULES:
+                    issues.append(
+                        "{} {}:{} {}".format(
+                            finding["test_id"],
+                            Path(finding["filename"]).name,
+                            finding["line_number"],
+                            finding["issue_text"],
+                        )
+                    )
+
+        secrets = _run(
+            [sys.executable, "-m", "detect_secrets", "scan", str(plugin_root)]
+        )
+        try:
+            secrets_data = json.loads(secrets.stdout)
+        except json.JSONDecodeError:
+            issues.append(
+                "detect-secrets did not return valid JSON: {}".format(secrets.stderr.strip())
+            )
+        else:
+            for filename, findings in secrets_data.get("results", {}).items():
+                for finding in findings:
+                    issues.append(
+                        "secret {}:{} {}".format(
+                            filename,
+                            finding.get("line_number"),
+                            finding.get("type"),
+                        )
+                    )
+
+        flake8_config = plugin_root / ".flake8"
+        flake8_command = [sys.executable, "-m", "flake8", str(plugin_root)]
+        if flake8_config.is_file():
+            flake8_command.extend(["--config", str(flake8_config)])
+        flake8 = _run(flake8_command)
+        if flake8.returncode:
+            issues.extend(line for line in flake8.stdout.splitlines() if line.strip())
+    return issues
+
+
+def latest_package(root: Path) -> Path:
+    packages = sorted(
+        (root / "dist").glob("qgis_agent_mcp-*.zip"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    if not packages:
+        raise FileNotFoundError("No plugin ZIP found in dist; run scripts/build_plugin.py first")
+    return packages[0]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run QGIS publication security checks")
+    parser.add_argument("package", nargs="?", type=Path)
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    package = (args.package or latest_package(root)).resolve()
+    issues = scan_package(package)
+    if issues:
+        print("QGIS publication security gate failed:")
+        for issue in issues:
+            print("- {}".format(issue))
+        return 1
+    print("QGIS publication security gate passed for {}".format(package))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/qgis_mcp/server.py
+++ b/src/qgis_mcp/server.py
@@ -98,8 +98,8 @@ class McpServer:
                 "Operate on the live QGIS session. Start with qgis_session_snapshot. Use "
                 "qgis_tools to discover specialist tools and qgis_tool_call to invoke a "
                 "hidden specialist without loading the full catalog. Prefer structured tools, "
-                "discover capabilities before invoking them, "
-                "and use qgis_python_exec only as an explicit escape hatch. Large data "
+                "discover capabilities before invoking them, and use QGIS Processing for "
+                "provider algorithms. Large data "
                 "stays in QGIS and is returned through summaries, pages, or handles."
             ),
         }
@@ -135,9 +135,7 @@ class McpServer:
 
     async def _execute_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         timeout = 120.0
-        if name == "qgis_python_exec":
-            timeout = min(305.0, float(arguments.get("timeout_ms", 30000)) / 1000 + 5)
-        elif name == "qgis_batch":
+        if name == "qgis_batch":
             timeout = 305.0
         result = await self.bridge.request(
             self.tools.method_for(name), arguments, timeout=timeout

--- a/src/qgis_mcp/tool_catalog.py
+++ b/src/qgis_mcp/tool_catalog.py
@@ -219,19 +219,6 @@ TOOLS: list[dict[str, Any]] = [
         ),
     },
     {
-        "name": "qgis_python_exec",
-        "description": "Execute Python/PyQGIS in the live QGIS interpreter. This explicit escape hatch is disabled unless enabled in plugin settings or QGIS_MCP_ENABLE_PYTHON=1.",
-        "inputSchema": _object(
-            {
-                "code": {"type": "string"},
-                "mode": {"type": "string", "enum": ["eval", "exec"], "default": "exec"},
-                "result_expression": {"type": "string"},
-                "timeout_ms": {"type": "integer", "minimum": 1, "maximum": 300000, "default": 30000},
-            },
-            ["code"],
-        ),
-    },
-    {
         "name": "qgis_ui_search",
         "description": "Search open Qt windows, docks, actions, menus, toolbars, and widgets by semantic object names and visible text.",
         "inputSchema": _object(
@@ -1828,7 +1815,6 @@ _MUTATION_TOOLS = {
     "qgis_capability_invoke",
     "qgis_processing_start",
     "qgis_operation",
-    "qgis_python_exec",
     "qgis_ui_invoke",
     "qgis_batch",
     "qgis_artifact_release",
@@ -1936,7 +1922,6 @@ TOOL_METHODS = {
     "qgis_capability_invoke": "capabilities.invoke",
     "qgis_processing_start": "processing.start",
     "qgis_operation": "operation.control",
-    "qgis_python_exec": "python.exec",
     "qgis_ui_search": "ui.search",
     "qgis_ui_invoke": "ui.invoke",
     "qgis_screenshot": "ui.screenshot",

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -168,9 +168,14 @@ def test_plugin_zip_contains_bundled_server_and_no_markdown(tmp_path):
     output = build_plugin(ROOT, tmp_path / "plugin.zip")
     with zipfile.ZipFile(output) as archive:
         names = set(archive.namelist())
+        metadata = archive.read("qgis_agent_mcp/metadata.txt").decode("utf-8")
     assert "qgis_agent_mcp/metadata.txt" in names
+    assert "qgis_agent_mcp/.flake8" in names
     assert "qgis_agent_mcp/icon.png" in names
     assert "qgis_agent_mcp/LICENSE" in names
     assert "qgis_agent_mcp/_server/qgis_mcp/__main__.py" in names
     assert not any(name.casefold().endswith(".md") for name in names)
     assert not any("__pycache__" in name for name in names)
+    assert "qgisMinimumVersion=3.44" in metadata
+    assert "qgisMaximumVersion=3.99" in metadata
+    assert "experimental=False" in metadata

--- a/tests/test_publication_security.py
+++ b/tests/test_publication_security.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from build_plugin import build_plugin
+from check_qgis_plugin_security import (
+    QGIS_BLOCKING_BANDIT_RULES,
+    validate_package_structure,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_security_gate_tracks_non_skippable_python_execution_rules():
+    assert {"B102", "B307"} <= QGIS_BLOCKING_BANDIT_RULES
+
+
+def test_built_plugin_passes_publication_structure_checks(tmp_path):
+    package = build_plugin(ROOT, tmp_path / "qgis_agent_mcp.zip")
+    root, issues = validate_package_structure(package)
+    assert root == "qgis_agent_mcp"
+    assert issues == []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -73,6 +73,12 @@ def test_full_catalog_mode_remains_available():
     assert names == set(TOOL_METHODS) | DISCOVERY_TOOL_NAMES
 
 
+def test_catalog_excludes_arbitrary_python_execution():
+    assert "qgis_python_exec" not in {tool["name"] for tool in TOOLS}
+    assert "qgis_python_exec" not in TOOL_METHODS
+    assert "python.exec" not in TOOL_METHODS.values()
+
+
 def test_adaptive_catalog_has_bounded_default_context_cost():
     status = ToolRegistry("adaptive").status()
     assert status["catalog_tools"] == len(TOOLS)


### PR DESCRIPTION
## What changed

- remove the arbitrary Python execution escape hatch from the public MCP catalog and QGIS bridge
- publish stable metadata for QGIS 3.44–3.99 with explicit client requirements and safety properties
- add the QGIS-compatible Flake8 configuration to the plugin package
- add a publication security gate that scans the built ZIP with Bandit, detect-secrets, Flake8, structural validation, binary detection, and package limits

## Why

The QGIS Plugins security scanner classifies `exec()` and `eval()` as critical, enabled, non-skippable findings. The previous opt-in Python escape hatch would therefore block the plugin from download and approval even when disabled by default.

## Impact

Agents retain the adaptive catalog of 100+ typed QGIS tools, Processing access, guarded workflows, restart recovery, and visual review. Arbitrary code execution is no longer exposed by the public plugin.

## Validation

- 58 Python tests passed
- Ruff passed
- compileall passed
- built `qgis_agent_mcp-0.4.2.zip` at 266 KB
- QGIS publication security gate passed
- no binaries, secrets, generated caches, or invalid package paths