### PR TITLE
Document blank-project demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Connect AI agents to a live QGIS Desktop session through a secure local MCP brid
 
 - **100+ specialist QGIS tools** across projects, vector, raster, Processing, databases, cartography, layouts, 3D, point clouds and more.
 - **Low context cost:** only 14 core tools are loaded by default; agents discover and activate specialist tools when needed.
-- **One-click connection:** configure Codex or Claude Code directly from QGIS, with a universal MCP configuration for other clients.
+- **One-click connection:** safely configure open-source OpenCode, Codex, Claude Code, Cursor or Google Antigravity directly from QGIS, with a universal MCP configuration for other clients.
 - **Safe autonomy:** revision guards, idempotency, checkpoints, atomic workflows and recovery after a QGIS restart.
 - **Visual review:** agents can inspect rendered maps, apply bounded corrections and review the result again.
 - **Local by design:** authenticated loopback transport; project data stays inside QGIS.
@@ -20,7 +20,7 @@ Connect AI agents to a live QGIS Desktop session through a secure local MCP brid
 1. Download the latest `qgis_agent_mcp-*.zip` from [Releases](https://github.com/Aaa2122/QGIS-MCP/releases).
 2. In QGIS, open **Plugins → Manage and Install Plugins → Install from ZIP**.
 3. Enable **QGIS Agent MCP** and click **Connect an AI client**.
-4. Select **Connect / Repair** for Codex or Claude Code, then restart the AI client.
+4. Select **Connect / Repair** for your AI client, follow the displayed restart guidance, then reopen the client.
 
 No port, token or configuration file needs to be copied manually.
 
@@ -30,6 +30,33 @@ No port, token or configuration file needs to be copied manually.
 
 The agent can also search the complete specialist catalog without loading every tool schema into its context.
 
+## Demos: from a blank project to a finished QGIS map
+
+Both demos start from the same clean state: a **new, empty QGIS project** with no prepared layers, styles or layout. The user connects an AI client through QGIS Agent MCP, describes the task, and the agent builds the project in the live QGIS session.
+
+### Demo 1 — Wildfire monitoring
+
+**Starting point:** blank QGIS project → **result:** a France-wide monitoring map with prioritized detections, age categories, labels and a focused Bordeaux view.
+
+<p align="center">
+  <img src="capture%20demo/wildfire-monitoring-france-overview.png" alt="Wildfire monitoring map generated from a blank QGIS project, France overview" width="49%">
+  <img src="capture%20demo/wildfire-monitoring-bordeaux-detail.png" alt="Wildfire monitoring map generated from a blank QGIS project, Bordeaux detail" width="49%">
+</p>
+
+<p align="center"><em>Blank project → national overview → local detection detail</em></p>
+
+### Demo 2 — Agricultural data exploration
+
+**Starting point:** blank QGIS project → **result:** annual agricultural parcel data combined with satellite imagery, from the national view down to a detailed parcel map with a crop legend.
+
+<p align="center">
+  <img src="capture%20demo/agriculture-france-overview.png" alt="Agricultural data map generated from a blank QGIS project, France overview" width="32%">
+  <img src="capture%20demo/agriculture-parcels-overview.png" alt="Agricultural parcel map generated from a blank QGIS project, regional overview" width="32%">
+  <img src="capture%20demo/agriculture-parcel-detail.png" alt="Agricultural parcel detail and crop legend generated from a blank QGIS project" width="32%">
+</p>
+
+<p align="center"><em>Blank project → national coverage → parcel overview → detailed crop map</em></p>
+
 ## Safety
 
 The bridge accepts only authenticated local connections and does not expose arbitrary Python execution. Agents use typed tools, QGIS Processing algorithms and guarded workflows instead.
@@ -37,7 +64,7 @@ The bridge accepts only authenticated local connections and does not expose arbi
 ## Compatibility
 
 - QGIS 3.44 LTR or newer in the 3.x series
-- Codex, Claude Code and standard stdio MCP clients
+- OpenCode, Codex, Claude Code, Cursor, Google Antigravity and standard stdio MCP clients
 - No external Python runtime dependency in the packaged plugin
 - Validated on QGIS LTR 3.44.12 with 19 live integration scenarios
 


### PR DESCRIPTION
## What changed
- Document the two QGIS demos in the README.
- Make the blank-project starting point explicit for both demos.
- Present the wildfire and agricultural workflows with their existing screenshots and captions.

## Why
The README now shows clearly how QGIS Agent MCP takes a new empty QGIS project to a finished, reviewable map.

## Validation
- Verified the staged README diff.
- Verified that all README demo image references resolve locally.